### PR TITLE
A work-around for missing JDK path

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/SbtPluginBuilder.java
+++ b/src/main/java/org/jvnet/hudson/plugins/SbtPluginBuilder.java
@@ -128,10 +128,14 @@ public class SbtPluginBuilder extends Builder {
 		}
 
 		// java
-		String java = build.getProject().getJDK() != null ? build.getProject()
-				.getJDK().getBinDir()
-				+ "/java" : "java";
-		args.add(new File(java).getAbsolutePath());
+		String javaExePath;
+		if (build.getProject().getJDK() != null) {
+			javaExePath = new File(build.getProject().getJDK().getBinDir()
+					+ "/java").getAbsolutePath();
+		} else {
+			javaExePath = "java";
+		}
+		args.add(javaExePath);
 
 		String[] split = jvmFlags.split(" ");
 		for (String flag : split) {


### PR DESCRIPTION
As it stands, if the JDK path is empty SBT plugin will try to use `/java` as the executable path, which will normally fail. This work-around prevents the plugin from resolving absolute path if JDK information is not present; it will be assumed that `java` is available in `$PATH`.
