### PR TITLE
Fix the Java executable path in a Windows-master/Linux-Node setup

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/SbtPluginBuilder.java
+++ b/src/main/java/org/jvnet/hudson/plugins/SbtPluginBuilder.java
@@ -193,8 +193,7 @@ public class SbtPluginBuilder extends Builder {
             }
 
             if (jdk != null) {
-                javaExePath = new File(jdk.getBinDir()
-                    + "/java").getAbsolutePath();
+                javaExePath = jdk.getHome() + "/bin/java";
             } else {
                 javaExePath = "java";
             }


### PR DESCRIPTION
A more detailed explanation on why this hack seems to be the only working way can be found in this comment: https://github.com/wolfg1969/sbt-plugin/commit/c3f25fa47610407e290368454856cc556a0bd0c9#commitcomment-2720826
