### PR TITLE
Use regex to split sbt arguments. Otherwise arguments that are split by ...

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/SbtPluginBuilder.java
+++ b/src/main/java/org/jvnet/hudson/plugins/SbtPluginBuilder.java
@@ -234,7 +234,7 @@ public class SbtPluginBuilder extends Builder {
             return;
         }
 
-        String[] split = argsToSplit.split(" ");
+        String[] split = argsToSplit.split("\\s+");
         for (String flag : split) {
             args.add(flag);
         }


### PR DESCRIPTION
...double spaces will result in `Could not find or load main class` error which is extremely annoying to debug.
