### PR TITLE
Added support for environment variables in 'actions'

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/SbtPluginBuilder.java
+++ b/src/main/java/org/jvnet/hudson/plugins/SbtPluginBuilder.java
@@ -28,6 +28,7 @@ import hudson.util.ArgumentListBuilder;
 import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.text.StrSubstitutor;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -222,7 +223,8 @@ public class SbtPluginBuilder extends Builder {
 
             args.add(launcherPath);
 
-            for (String action : split(actions)) {
+            String subActions = new StrSubstitutor(env).replace(actions);
+            for (String action : split(subActions)) {
                 args.add(action);
             }
         }


### PR DESCRIPTION
It is useful when you want the sbt actions to be generated. For example - when you dynamically determine the projects to build, or 'clean' only in when some condition is true, etc...
