### PR TITLE
JENKINS-24346: add an extra set of quotes after cmd/c to handle paths wi...

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/SbtPluginBuilder.java
+++ b/src/main/java/org/jvnet/hudson/plugins/SbtPluginBuilder.java
@@ -180,6 +180,8 @@ public class SbtPluginBuilder extends Builder {
 
             if (!launcher.isUnix()) {
                 args.add("cmd.exe", "/C");
+                // add an extra set of quotes after cmd/c to handle paths with spaces in Windows
+                args.add("\"");
             }
 
             // java
@@ -224,6 +226,10 @@ public class SbtPluginBuilder extends Builder {
 
             for (String action : split(actions)) {
                 args.add(action);
+            }
+
+            if (!launcher.isUnix()) {
+                args.add("\"");
             }
         }
 
@@ -524,3 +530,4 @@ public class SbtPluginBuilder extends Builder {
         }
     }
 }
+


### PR DESCRIPTION
...th spaces in Windows. (Fix for https://issues.jenkins-ci.org/browse/JENKINS-24346)
