### PR TITLE
add support for system configuration of SBT installations

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/SbtPluginBuilder.java
+++ b/src/main/java/org/jvnet/hudson/plugins/SbtPluginBuilder.java
@@ -351,10 +351,10 @@ public class SbtPluginBuilder extends Builder {
         private String sbtArguments;
 
         @DataBoundConstructor
-        public SbtInstallation(String name, String home, String arguments, List<? extends ToolProperty<?>> properties) {
+        public SbtInstallation(String name, String home, String sbtArguments, List<? extends ToolProperty<?>> properties) {
             super(name, launderHome(home), properties);
-            this.sbtArguments = arguments;
-            LOGGER.fine("got sbtArguments config: " + arguments);
+            this.sbtArguments = sbtArguments;
+            LOGGER.fine("got sbtArguments config: " + sbtArguments);
         }
 
         private static String launderHome(String home) {

--- a/src/main/resources/org/jvnet/hudson/plugins/SbtPluginBuilder/SbtInstallation/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/SbtPluginBuilder/SbtInstallation/config.jelly
@@ -8,7 +8,7 @@
     <f:entry title="sbt launch jar" field="home">
         <f:textbox />
     </f:entry>
-    <f:entry title="sbt launch arguments" field="arguments">
+    <f:entry title="sbt launch arguments" field="sbtArguments">
         <f:textbox />
     </f:entry>
 </j:jelly>


### PR DESCRIPTION
This pull request adds a system-wide configuration option to add parameters to the sbt call. For example, this can be used to change the `.sbt` directory for different installations of SBT.

Note that I have no idea how to write Jenkins plugins. I think I should have used `ToolProperty`, but I wasn't able to find an example of how to do it. If you know a better way of adding this functionality, please tell me.
