### PR TITLE
Substitute environment variables in sub-directory path

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/SbtPluginBuilder.java
+++ b/src/main/java/org/jvnet/hudson/plugins/SbtPluginBuilder.java
@@ -121,7 +121,8 @@ public class SbtPluginBuilder extends Builder {
             env = build.getEnvironment(listener);
 
             if (subdirPath != null && subdirPath.length() > 0) {
-                workDir = new FilePath(workDir, subdirPath);
+                String subSubdirPath = new StrSubstitutor(env).replace(subdirPath);
+                workDir = new FilePath(workDir, subSubdirPath);
             }
 
             int exitValue = launcher.launch().cmds(cmds).envs(env)


### PR DESCRIPTION
This PR makes it possible to use environment variables in the sub-directory path.

This is useful for example for setting up a Jenkins job where the repository contains several distinct projects with their own sbt build definitions and a build parameter (manifested as an environment variable) allows defining which subdirectory to start sbt in.