### PR TITLE
Update The PATH Values For Tool Installation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.431</version>
+    <version>3.50</version>
     <!--<relativePath>../pom.xml</relativePath>-->
   </parent>
 
@@ -14,6 +14,10 @@
   <description>Build your scala project using sbt in Jenkins</description>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/sbt+plugin</url>
 
+  <properties>
+    <java.level>8</java.level>
+  </properties>
+
   <developers>
     <developer>
       <id>uzilan</id>
@@ -21,7 +25,7 @@
       <email>uzi.landsmann@gmail.com</email>
     </developer>
   </developers>
-  
+
   <licenses>
     <license>
       <name>The MIT License</name>
@@ -29,14 +33,14 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
-  
+
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/sbt-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/sbt-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/sbt-plugin</url>
     <tag>HEAD</tag>
   </scm>
-  
+
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
@@ -55,8 +59,25 @@
   	<dependency>
   		<groupId>commons-lang</groupId>
   		<artifactId>commons-lang</artifactId>
-  		<version>2.5</version>
+  		<version>2.6</version>
   	</dependency>
   </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <showDeprecation>true</showDeprecation>
+            <compilerArgs>
+              <arg>-Xlint:all</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 
 </project>

--- a/src/main/java/org/jvnet/hudson/plugins/SbtPluginBuilder.java
+++ b/src/main/java/org/jvnet/hudson/plugins/SbtPluginBuilder.java
@@ -413,6 +413,12 @@ public class SbtPluginBuilder extends Builder {
             return sbtArguments;
         }
 
+        @Override
+        public final void buildEnvVars(final EnvVars env) {
+            final String home = super.getHome();
+            env.put("PATH+SBT", home + "/bin");
+        }
+
         @Extension
         public static class DescriptorImpl extends ToolDescriptor<SbtInstallation> {
 

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,8 +1,9 @@
 <!--
   This view is used to render the plugin list page.
 
-  Since we don't really have anything dynamic here, let's just use static HTML. 
+  Since we don't really have anything dynamic here, let's just use static HTML.
 -->
+<?jelly escape-by-default='true'?>
 <div>
-  This plugin allows running SBT empowered scala projects in Hudson. 
+  This plugin allows running SBT empowered scala projects in Hudson.
 </div>

--- a/src/main/resources/org/jvnet/hudson/plugins/SbtPluginBuilder/SbtInstallation/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/SbtPluginBuilder/SbtInstallation/config.jelly
@@ -1,6 +1,7 @@
 <!--
   Config page
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:entry title="${%name}" field="name">
         <f:textbox />

--- a/src/main/resources/org/jvnet/hudson/plugins/SbtPluginBuilder/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/SbtPluginBuilder/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <!--
     This jelly script is used for per-project configuration.


### PR DESCRIPTION
This commit implements the `buildEnvVars` method from `ToolInstallation`. This method is used to add values to the `PATH` so that the tool is available. For example, prior to this commit implementing a Jenkins declarative pipeline using the sbt tool would look something like this.

```
pipeline {
    agent any
    stages {
        stage('Build') {
            steps {
                sh "${tool name: 'sbt', type: 'org.jvnet.hudson.plugins.SbtPluginBuilder$SbtInstallation'}/bin/sbt +clean +test"
            }
        }
        stage('Release') {
            steps {
                sh "${tool name: 'sbt', type: 'org.jvnet.hudson.plugins.SbtPluginBuilder$SbtInstallation'}/bin/sbt +'release with-defaults'"
            }
        }
    }
}
```

Note the very verbose duplicated `${tool name: 'sbt', type: 'org.jvnet.hudson.plugins.SbtPluginBuilder$SbtInstallation'}/bin/sbt docker:publishLocal"`.

After this commit one can use this plugin as intended by the Jenkins declarative pipeline (https://jenkins.io/doc/book/pipeline/syntax/#tools).

```
pipeline {
    agent any
    tools {
        'org.jvnet.hudson.plugins.SbtPluginBuilder$SbtInstallation' 'sbt'
    }
    stages {
        stage('Build') {
            steps {
                sh "sbt +clean +test"
            }
        }
        stage('Release') {
            steps {
                sh "sbt +'release with-defaults'"
            }
        }
    }
}
```