### PR TITLE
Fix sub-directory path substitution

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/SbtPluginBuilder.java
+++ b/src/main/java/org/jvnet/hudson/plugins/SbtPluginBuilder.java
@@ -119,6 +119,7 @@ public class SbtPluginBuilder extends Builder {
                 listener);
             String[] cmds = cmdLine.toCommandArray();
             env = build.getEnvironment(listener);
+            env.overrideAll(build.getBuildVariables());
 
             if (subdirPath != null && subdirPath.length() > 0) {
                 String subSubdirPath = new StrSubstitutor(env).replace(subdirPath);


### PR DESCRIPTION
This makes possible to define a variable based sub-directory path. This is a fix for this feature:
https://github.com/jenkinsci/sbt-plugin/pull/17 since Jenkins doesn't automatically expose build variables to the running job anymore.